### PR TITLE
fix: TextDecoder in parseJsonStream's global scope causes unsupported…

### DIFF
--- a/packages/client/src/links/internals/parseJSONStream.ts
+++ b/packages/client/src/links/internals/parseJSONStream.ts
@@ -36,6 +36,8 @@ export async function parseJSONStream<TReturn>(opts: {
   parse?: (text: string) => TReturn;
   signal?: AbortSignal;
 }): Promise<void> {
+  const textDecoder = new TextDecoder();
+
   const parse = opts.parse ?? JSON.parse;
 
   const onLine = (line: string) => {
@@ -55,10 +57,8 @@ export async function parseJSONStream<TReturn>(opts: {
     opts.onSingle(Number(indexAsStr), parse(text));
   };
 
-  await readLines(opts.readableStream, onLine);
+  await readLines(opts.readableStream, onLine, textDecoder);
 }
-
-const textDecoder = new TextDecoder();
 
 /**
  * Handle transforming a stream of bytes into lines of text.
@@ -71,6 +71,7 @@ const textDecoder = new TextDecoder();
 async function readLines(
   readableStream: ReadableStream<Uint8Array> | NodeJS.ReadableStream,
   onLine: (line: string) => void,
+  textDecoder: TextDecoder,
 ) {
   let partOfLine = '';
 


### PR DESCRIPTION
… environments to crash

This prevents environments where TextDecoder is unavailable from crashing. They now have the option to avoid using batch streaming for the time being. Previously, the initialization of TextDecoder in the global scope caused crashes in environments that don't support TextDecoder. This should resolve that issue.

## 🎯 Changes

This update addresses a bug to ensure compatibility with environments lacking support for TextDecoder.

## ✅ Checklist

- [x] I have followed all the steps outlined in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] Documentation related to the changes made has been added, if necessary.
- [ ] Tests related to the changes made have been added or updated.
